### PR TITLE
Add typing indicator to chat bot responses

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,0 +1,267 @@
+const ChatQuiz = (() => {
+  const chatFlow = [
+    {
+      prompt: "¿Qué tipo de energía te representa mejor?",
+      options: [
+        "Sofisticada y elegante, siempre impecable",
+        "Misteriosa y profunda, con múltiples capas",
+        "Explosiva y brillante, llena de vida",
+        "Dulce y reconfortante, como un abrazo",
+        "Fresca y juvenil, siempre renovándome",
+        "Intensa y apasionada, sin términos medios",
+      ],
+    },
+    {
+      prompt: "¿Cómo te comportas en una relación o amistad?",
+      options: [
+        "Romántica y soñadora, creo en el amor verdadero",
+        "Leal y protectora, siempre presente",
+        "Coqueta y juguetona, me gusta el misterio",
+        "Digital y moderna, conectamos online",
+        "Intensa y directa, voy tras lo que quiero",
+        "Energética y divertida, nunca me aburro",
+      ],
+    },
+    {
+      prompt: "¿Qué plan te hace feliz un domingo?",
+      options: [
+        "Maratón de series con snacks infinitos",
+        "Salir a un café bonito y tomar fotos",
+        "Crear playlists y bailar en casa",
+        "Día creativo: journaling, dibujo o collages",
+        "Reunión tranquila con amigos cercanos",
+        "Spa casero con mascarillas y velas",
+      ],
+    },
+  ];
+
+  const introMessage = "¡Vamos a empezar de nuevo! 💖";
+  let stepIndex = 0;
+  const avatarChoices = [
+    "assets/gptJp.jpg",
+    "assets/meow.jpeg",
+    "assets/metamorphic.jpeg",
+    "assets/stereotype.jpeg",
+    "assets/teddy-bear-jp.jpg",
+    "assets/poppy.jpg",
+  ];
+
+  const chatToggle = document.getElementById("chat-toggle");
+  const chatbox = document.getElementById("chatbox");
+  const chatClose = document.getElementById("chat-close");
+  const messages = document.getElementById("chat-messages");
+  const optionsContainer = document.getElementById("chat-options");
+  const activeTimeouts = new Set();
+  let shouldStartNewSession = true;
+
+  if (!chatToggle || !chatbox || !chatClose || !messages || !optionsContainer) {
+    return {};
+  }
+
+  const scrollToBottom = () => {
+    messages.scrollTop = messages.scrollHeight;
+  };
+
+  const schedule = (fn, delay) => {
+    const id = setTimeout(() => {
+      activeTimeouts.delete(id);
+      fn();
+    }, delay);
+    activeTimeouts.add(id);
+    return id;
+  };
+
+  const clearScheduledResponses = () => {
+    activeTimeouts.forEach((id) => clearTimeout(id));
+    activeTimeouts.clear();
+  };
+
+  const removeTypingIndicators = () => {
+    messages.querySelectorAll(".typing-indicator").forEach((node) => node.remove());
+  };
+
+  const addBotBubble = (text) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "chat-message bot";
+
+    const avatar = document.createElement("div");
+    avatar.className = "chat-avatar-small";
+
+    const bubble = document.createElement("div");
+    bubble.className = "message-bubble";
+    bubble.textContent = text;
+
+    wrapper.appendChild(avatar);
+    wrapper.appendChild(bubble);
+    messages.appendChild(wrapper);
+    scrollToBottom();
+  };
+
+  const showTypingIndicator = () => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "chat-message bot typing-indicator";
+
+    const avatar = document.createElement("div");
+    avatar.className = "chat-avatar-small";
+
+    const bubble = document.createElement("div");
+    bubble.className = "message-bubble typing-bubble";
+
+    const dots = document.createElement("div");
+    dots.className = "typing-dots";
+
+    [0, 1, 2].forEach((index) => {
+      const dot = document.createElement("span");
+      dot.className = "typing-dot";
+      dot.style.animationDelay = `${index * 0.12}s`;
+      dots.appendChild(dot);
+    });
+
+    bubble.appendChild(dots);
+    wrapper.appendChild(avatar);
+    wrapper.appendChild(bubble);
+    messages.appendChild(wrapper);
+    scrollToBottom();
+    return wrapper;
+  };
+
+  const addBotMessage = (text, withTyping = true) => {
+    if (!withTyping) {
+      addBotBubble(text);
+      return;
+    }
+
+    const indicator = showTypingIndicator();
+    schedule(() => {
+      indicator.remove();
+      addBotBubble(text);
+    }, 650);
+  };
+
+  const addUserMessage = (text) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "chat-message user";
+
+    const bubble = document.createElement("div");
+    bubble.className = "message-bubble";
+    bubble.textContent = text;
+
+    wrapper.appendChild(bubble);
+    messages.appendChild(wrapper);
+    scrollToBottom();
+  };
+
+  const renderOptions = (options) => {
+    optionsContainer.innerHTML = "";
+
+    options.forEach((option) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "chat-option";
+      button.textContent = option;
+      button.addEventListener("click", () => handleOption(option));
+      optionsContainer.appendChild(button);
+    });
+  };
+
+  const renderCompletion = () => {
+    addBotMessage("¡Listo! Gracias por jugar. ¿Quieres reiniciar?");
+    optionsContainer.innerHTML = "";
+
+    const restart = document.createElement("button");
+    restart.type = "button";
+    restart.className = "chat-option";
+    restart.textContent = "Volver a empezar";
+    restart.addEventListener("click", startConversation);
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "chat-option";
+    close.textContent = "Cerrar chat";
+    close.addEventListener("click", () => {
+      closeChat();
+    });
+
+    optionsContainer.appendChild(restart);
+    optionsContainer.appendChild(close);
+  };
+
+  const askCurrentStep = () => {
+    const step = chatFlow[stepIndex];
+    if (!step) {
+      renderCompletion();
+      return;
+    }
+
+    addBotMessage(step.prompt);
+    renderOptions(step.options);
+  };
+
+  const handleOption = (choice) => {
+    addUserMessage(choice);
+    stepIndex += 1;
+
+    if (stepIndex < chatFlow.length) {
+      schedule(() => {
+        askCurrentStep();
+      }, 450);
+    } else {
+      schedule(() => {
+        renderCompletion();
+      }, 380);
+    }
+  };
+
+  const pickAvatar = () => {
+    const randomIndex = Math.floor(Math.random() * avatarChoices.length);
+    const chosenAvatar = avatarChoices[randomIndex];
+    chatbox.style.setProperty("--chat-avatar-url", `url("${chosenAvatar}")`);
+  };
+
+  const startConversation = () => {
+    clearScheduledResponses();
+    removeTypingIndicators();
+    pickAvatar();
+    messages.innerHTML = "";
+    optionsContainer.innerHTML = "";
+    stepIndex = 0;
+    shouldStartNewSession = false;
+    addBotMessage(introMessage);
+    schedule(() => {
+      askCurrentStep();
+    }, 400);
+  };
+
+  const openChat = () => {
+    chatbox.classList.add("open");
+    chatToggle.setAttribute("aria-expanded", "true");
+    if (shouldStartNewSession) {
+      startConversation();
+    }
+  };
+
+  const closeChat = () => {
+    clearScheduledResponses();
+    removeTypingIndicators();
+    chatbox.classList.remove("open");
+    chatToggle.setAttribute("aria-expanded", "false");
+    messages.innerHTML = "";
+    optionsContainer.innerHTML = "";
+    shouldStartNewSession = true;
+  };
+
+  chatToggle.addEventListener("click", () => {
+    if (chatbox.classList.contains("open")) {
+      closeChat();
+    } else {
+      openChat();
+    }
+  });
+
+  chatClose.addEventListener("click", closeChat);
+
+  return {
+    open: openChat,
+    close: closeChat,
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -288,7 +288,31 @@
           </footer>
         </div>
 
+        <button id="chat-toggle" class="chat-toggle" aria-label="Abrir chat interactivo" aria-expanded="false">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+          </svg>
+        </button>
+
+        <div id="chatbox" class="chatbox" aria-live="polite">
+          <div class="chatbox-header">
+            <div class="chatbox-title">
+              <div class="chat-avatar"></div>
+              <div>
+                <h4>Photocard Quiz 💖</h4>
+                <p class="chatbox-subtitle">Responde y descubre tu vibe</p>
+              </div>
+            </div>
+            <button id="chat-close" class="chat-close" aria-label="Cerrar chat">×</button>
+          </div>
+          <div class="chatbox-body">
+            <div id="chat-messages" class="chat-messages"></div>
+            <div id="chat-options" class="chat-options"></div>
+          </div>
+        </div>
+
         <!-- Scripts -->
+        <script src="chat.js"></script>
         <script src="songs.js"></script>
         <script src="ranker.js"></script>
         </body>

--- a/styles.css
+++ b/styles.css
@@ -780,6 +780,240 @@ footer a:hover {
   text-decoration: none;
 }
 
+/* Chatbox Styles */
+.chat-toggle {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: none;
+  background: #0f172a;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  z-index: 1500;
+}
+
+.chat-toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.3);
+  background: #11182c;
+}
+
+.chatbox {
+  position: fixed;
+  bottom: 110px;
+  right: 24px;
+  width: 360px;
+  max-width: calc(100% - 32px);
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
+  border: 1px solid #e5e7eb;
+  overflow: hidden;
+  display: none;
+  flex-direction: column;
+  z-index: 1499;
+}
+
+.chatbox.open {
+  display: flex;
+}
+
+.chatbox-header {
+  background: #0f172a;
+  color: #ffffff;
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.chatbox-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.chatbox-title h4 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+}
+
+.chatbox-subtitle {
+  margin: 2px 0 0;
+  font-size: 0.88rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.chat-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: #ffffff;
+  background-image: var(--chat-avatar-url, url("assets/gptJp.jpg"));
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.15);
+  border: 2px solid #e5e7eb;
+  flex-shrink: 0;
+}
+
+.chat-close {
+  background: transparent;
+  border: none;
+  color: #ffffff;
+  font-size: 20px;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 8px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.chat-close:hover {
+  background: rgba(255, 255, 255, 0.12);
+  transform: scale(1.03);
+}
+
+.chatbox-body {
+  background: #f7f8fb;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.chat-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.chat-message {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.chat-avatar-small {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background-image: var(--chat-avatar-url, url("assets/gptJp.jpg"));
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+  border: 2px solid #ffffff;
+  flex-shrink: 0;
+}
+
+.message-bubble {
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  max-width: 78%;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.chat-message.bot .message-bubble {
+  border-bottom-left-radius: 6px;
+}
+
+.chat-message.typing-indicator .message-bubble {
+  border-bottom-left-radius: 6px;
+  background: #e2e8f0;
+  border-color: #e2e8f0;
+  box-shadow: none;
+}
+
+.chat-message.user {
+  justify-content: flex-end;
+}
+
+.chat-message.user .message-bubble {
+  background: var(--primary);
+  color: #ffffff;
+  border-color: var(--primary);
+  border-bottom-right-radius: 6px;
+}
+
+.chat-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-option {
+  width: 100%;
+  text-align: left;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  padding: 12px 14px;
+  border-radius: 12px;
+  font-weight: 600;
+  color: var(--text-dark);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.typing-bubble {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 82px;
+}
+
+.typing-dots {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.typing-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #cbd5e1;
+  animation: typingBounce 1.1s infinite ease-in-out;
+}
+
+@keyframes typingBounce {
+  0%,
+  80%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-4px);
+  }
+}
+
+.chat-option:hover {
+  transform: translateY(-1px);
+  border-color: var(--primary);
+  box-shadow: 0 12px 22px rgba(255, 95, 162, 0.15);
+}
+
+.chat-option:focus {
+  outline: 2px solid var(--primary-light);
+  outline-offset: 2px;
+}
+
 /* Responsive Styles */
 @media (max-width: 768px) {
   header h1 {
@@ -805,6 +1039,25 @@ footer a:hover {
 
   .vs-badge {
     margin: 10px 0;
+  }
+
+  .chatbox {
+    width: 330px;
+    right: 16px;
+    bottom: 96px;
+  }
+
+  .chatbox-body {
+    padding: 14px;
+  }
+
+  .chat-messages {
+    max-height: 360px;
+  }
+
+  .chat-toggle {
+    right: 16px;
+    bottom: 16px;
   }
 
   .share-url-container {
@@ -890,6 +1143,32 @@ footer a:hover {
     font-size: 0.85rem;
     flex-wrap: wrap;
     justify-content: center;
+  }
+
+  .chatbox {
+    width: calc(100% - 24px);
+    right: 12px;
+    bottom: 90px;
+    border-radius: 14px;
+  }
+
+  .chat-toggle {
+    width: 56px;
+    height: 56px;
+    right: 12px;
+    bottom: 12px;
+  }
+
+  .chatbox-title h4 {
+    font-size: 0.95rem;
+  }
+
+  .chatbox-subtitle {
+    font-size: 0.82rem;
+  }
+
+  .message-bubble {
+    max-width: 88%;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a typing indicator bubble with animated dots before bot replies
- centralize scheduling for bot prompts to reset pending timeouts when closing or restarting the chat
- style the typing bubble to blend with the existing chat UI

## Testing
- echo "Tests not run (not requested)."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199a241ab8832395c2310311c51d72)