### PR TITLE
Add cookies to personalize chat intro

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -61,114 +61,42 @@ const ChatQuiz = (() => {
   ];
 
   const avatarMatchReplies = {
-    "assets/avatars/isa.webp": [
-      {
-        option: "Sofisticada y elegante, siempre impecable",
-        reply: "¡Ese estilo sofisticado es super Isa vibra!",
-      },
-      {
-        option: "Romántica y soñadora, creo en el amor verdadero",
-        reply: "También creo en esos romances de película.",
-      },
-      {
-        option: "Salir a un café bonito y tomar fotos",
-        reply: "Los cafecitos lindos son mi plan favorito.",
-      },
-      {
-        option: "Los bolsos",
-        reply: "¡A mí también me gustan los bolsos!",
-      },
-    ],
-    "assets/avatars/j.webp": [
-      {
-        option: "Misteriosa y profunda, con múltiples capas",
-        reply: "Me encanta esa aura misteriosa, te queda perfecta.",
-      },
-      {
-        option: "Leal y protectora, siempre presente",
-        reply: "La lealtad lo es todo, ¡gracias por tenerla!",
-      },
-      {
-        option: "Maratón de series con snacks infinitos",
-        reply: "Una buena serie y botanas es mi tarde ideal.",
-      },
-      {
-        option: "Las cámaras desechables",
-        reply: "Siempre llevo una cámara para capturar recuerdos.",
-      },
-    ],
-    "assets/avatars/seeun.webp": [
-      {
-        option: "Explosiva y brillante, llena de vida",
-        reply: "¡Esa energía brillante me inspira muchísimo!",
-      },
-      {
-        option: "Coqueta y juguetona, me gusta el misterio",
-        reply: "Un poco de coqueteo siempre mantiene la chispa.",
-      },
-      {
-        option: "Crear playlists y bailar en casa",
-        reply: "Yo también vivo armando playlists interminables.",
-      },
-      {
-        option: "Los stickers",
-        reply: "Decoro todo con stickers, ¡son lo máximo!",
-      },
-    ],
-    "assets/avatars/sumin.webp": [
-      {
-        option: "Dulce y reconfortante, como un abrazo",
-        reply: "Esa dulzura reconfortante me representa un montón.",
-      },
-      {
-        option: "Digital y moderna, conectamos online",
-        reply: "Las conexiones online también pueden ser especiales.",
-      },
-      {
-        option: "Día creativo: journaling, dibujo o collages",
-        reply: "Un día creativo es mi terapia favorita.",
-      },
-      {
-        option: "Los vinilos",
-        reply: "El sonido en vinilo tiene una vibra única, ¿cierto?",
-      },
-    ],
-    "assets/avatars/sieun.webp": [
-      {
-        option: "Fresca y juvenil, siempre renovándome",
-        reply: "Renovarse y mantenerlo fresco es la clave.",
-      },
-      {
-        option: "Intensa y directa, voy tras lo que quiero",
-        reply: "Me encanta esa determinación para ir por todo.",
-      },
-      {
-        option: "Reunión tranquila con amigos cercanos",
-        reply: "Un plan chill con amigxs es justo lo que amo.",
-      },
-      {
-        option: "Los tenis",
-        reply: "Unos buenos tenis te acompañan a todas partes.",
-      },
-    ],
-    "assets/avatars/yoon.webp": [
-      {
-        option: "Intensa y apasionada, sin términos medios",
-        reply: "Esa pasión a tope me hace sentir super viva.",
-      },
-      {
-        option: "Energética y divertida, nunca me aburro",
-        reply: "¡La diversión sin pausa es la mejor manera de vivir!",
-      },
-      {
-        option: "Spa casero con mascarillas y velas",
-        reply: "Los spas caseros son mi ritual de amor propio.",
-      },
-      {
-        option: "Los coleccionables kawaii",
-        reply: "Todo lo kawaii me hace feliz, ¡somos dos!",
-      },
-    ],
+    "assets/avatars/isa.webp": {
+      "Sofisticada y elegante, siempre impecable": "¡Ese estilo sofisticado es super Isa vibra!",
+      "Romántica y soñadora, creo en el amor verdadero": "También creo en esos romances de película.",
+      "Salir a un café bonito y tomar fotos": "Los cafecitos lindos son mi plan favorito.",
+      "Los bolsos": "¡A mí también me gustan los bolsos!",
+    },
+    "assets/avatars/j.webp": {
+      "Misteriosa y profunda, con múltiples capas": "Me encanta esa aura misteriosa, te queda perfecta.",
+      "Leal y protectora, siempre presente": "La lealtad lo es todo, ¡gracias por tenerla!",
+      "Maratón de series con snacks infinitos": "Una buena serie y botanas es mi tarde ideal.",
+      "Las cámaras desechables": "Siempre llevo una cámara para capturar recuerdos.",
+    },
+    "assets/avatars/seeun.webp": {
+      "Explosiva y brillante, llena de vida": "¡Esa energía brillante me inspira muchísimo!",
+      "Coqueta y juguetona, me gusta el misterio": "Un poco de coqueteo siempre mantiene la chispa.",
+      "Crear playlists y bailar en casa": "Yo también vivo armando playlists interminables.",
+      "Los stickers": "Decoro todo con stickers, ¡son lo máximo!",
+    },
+    "assets/avatars/sumin.webp": {
+      "Dulce y reconfortante, como un abrazo": "Esa dulzura reconfortante me representa un montón.",
+      "Digital y moderna, conectamos online": "Las conexiones online también pueden ser especiales.",
+      "Día creativo: journaling, dibujo o collages": "Un día creativo es mi terapia favorita.",
+      "Los vinilos": "El sonido en vinilo tiene una vibra única, ¿cierto?",
+    },
+    "assets/avatars/sieun.webp": {
+      "Fresca y juvenil, siempre renovándome": "Renovarse y mantenerlo fresco es la clave.",
+      "Intensa y directa, voy tras lo que quiero": "Me encanta esa determinación para ir por todo.",
+      "Reunión tranquila con amigos cercanos": "Un plan chill con amigxs es justo lo que amo.",
+      "Los tenis": "Unos buenos tenis te acompañan a todas partes.",
+    },
+    "assets/avatars/yoon.webp": {
+      "Intensa y apasionada, sin términos medios": "Esa pasión a tope me hace sentir super viva.",
+      "Energética y divertida, nunca me aburro": "¡La diversión sin pausa es la mejor manera de vivir!",
+      "Spa casero con mascarillas y velas": "Los spas caseros son mi ritual de amor propio.",
+      "Los coleccionables kawaii": "Todo lo kawaii me hace feliz, ¡somos dos!",
+    },
   };
 
   const chatToggle = document.getElementById("chat-toggle");
@@ -406,17 +334,16 @@ const ChatQuiz = (() => {
 
   const handleOption = (choice) => {
     addUserMessage(choice);
-    const avatarReactions = avatarMatchReplies[currentAvatar] || [];
-    const reactionConfig = avatarReactions[stepIndex];
-    const shouldReact = reactionConfig && reactionConfig.option === choice;
+    const avatarReactions = avatarMatchReplies[currentAvatar] || {};
+    const reactionReply = avatarReactions[choice];
 
-    if (shouldReact) {
+    if (reactionReply) {
       schedule(() => {
-        addBotMessage(reactionConfig.reply);
+        addBotMessage(reactionReply);
       }, 280);
     }
 
-    const delayBeforeNext = shouldReact ? 1000 : 450;
+    const delayBeforeNext = reactionReply ? 1000 : 450;
     stepIndex += 1;
 
     if (stepIndex < chatFlow.length) {

--- a/chat.js
+++ b/chat.js
@@ -61,30 +61,114 @@ const ChatQuiz = (() => {
   ];
 
   const avatarMatchReplies = {
-    "assets/avatars/isa.webp": {
-      option: "Los bolsos",
-      reply: "¡A mí también me gustan los bolsos!",
-    },
-    "assets/avatars/j.webp": {
-      option: "Las cámaras desechables",
-      reply: "Siempre llevo una cámara para capturar recuerdos.",
-    },
-    "assets/avatars/seeun.webp": {
-      option: "Los stickers",
-      reply: "Decoro todo con stickers, ¡son lo máximo!",
-    },
-    "assets/avatars/sumin.webp": {
-      option: "Los vinilos",
-      reply: "El sonido en vinilo tiene una vibra única, ¿cierto?",
-    },
-    "assets/avatars/sieun.webp": {
-      option: "Los tenis",
-      reply: "Unos buenos tenis te acompañan a todas partes.",
-    },
-    "assets/avatars/yoon.webp": {
-      option: "Los coleccionables kawaii",
-      reply: "Todo lo kawaii me hace feliz, ¡somos dos!",
-    },
+    "assets/avatars/isa.webp": [
+      {
+        option: "Sofisticada y elegante, siempre impecable",
+        reply: "¡Ese estilo sofisticado es super Isa vibra!",
+      },
+      {
+        option: "Romántica y soñadora, creo en el amor verdadero",
+        reply: "También creo en esos romances de película.",
+      },
+      {
+        option: "Salir a un café bonito y tomar fotos",
+        reply: "Los cafecitos lindos son mi plan favorito.",
+      },
+      {
+        option: "Los bolsos",
+        reply: "¡A mí también me gustan los bolsos!",
+      },
+    ],
+    "assets/avatars/j.webp": [
+      {
+        option: "Misteriosa y profunda, con múltiples capas",
+        reply: "Me encanta esa aura misteriosa, te queda perfecta.",
+      },
+      {
+        option: "Leal y protectora, siempre presente",
+        reply: "La lealtad lo es todo, ¡gracias por tenerla!",
+      },
+      {
+        option: "Maratón de series con snacks infinitos",
+        reply: "Una buena serie y botanas es mi tarde ideal.",
+      },
+      {
+        option: "Las cámaras desechables",
+        reply: "Siempre llevo una cámara para capturar recuerdos.",
+      },
+    ],
+    "assets/avatars/seeun.webp": [
+      {
+        option: "Explosiva y brillante, llena de vida",
+        reply: "¡Esa energía brillante me inspira muchísimo!",
+      },
+      {
+        option: "Coqueta y juguetona, me gusta el misterio",
+        reply: "Un poco de coqueteo siempre mantiene la chispa.",
+      },
+      {
+        option: "Crear playlists y bailar en casa",
+        reply: "Yo también vivo armando playlists interminables.",
+      },
+      {
+        option: "Los stickers",
+        reply: "Decoro todo con stickers, ¡son lo máximo!",
+      },
+    ],
+    "assets/avatars/sumin.webp": [
+      {
+        option: "Dulce y reconfortante, como un abrazo",
+        reply: "Esa dulzura reconfortante me representa un montón.",
+      },
+      {
+        option: "Digital y moderna, conectamos online",
+        reply: "Las conexiones online también pueden ser especiales.",
+      },
+      {
+        option: "Día creativo: journaling, dibujo o collages",
+        reply: "Un día creativo es mi terapia favorita.",
+      },
+      {
+        option: "Los vinilos",
+        reply: "El sonido en vinilo tiene una vibra única, ¿cierto?",
+      },
+    ],
+    "assets/avatars/sieun.webp": [
+      {
+        option: "Fresca y juvenil, siempre renovándome",
+        reply: "Renovarse y mantenerlo fresco es la clave.",
+      },
+      {
+        option: "Intensa y directa, voy tras lo que quiero",
+        reply: "Me encanta esa determinación para ir por todo.",
+      },
+      {
+        option: "Reunión tranquila con amigos cercanos",
+        reply: "Un plan chill con amigxs es justo lo que amo.",
+      },
+      {
+        option: "Los tenis",
+        reply: "Unos buenos tenis te acompañan a todas partes.",
+      },
+    ],
+    "assets/avatars/yoon.webp": [
+      {
+        option: "Intensa y apasionada, sin términos medios",
+        reply: "Esa pasión a tope me hace sentir super viva.",
+      },
+      {
+        option: "Energética y divertida, nunca me aburro",
+        reply: "¡La diversión sin pausa es la mejor manera de vivir!",
+      },
+      {
+        option: "Spa casero con mascarillas y velas",
+        reply: "Los spas caseros son mi ritual de amor propio.",
+      },
+      {
+        option: "Los coleccionables kawaii",
+        reply: "Todo lo kawaii me hace feliz, ¡somos dos!",
+      },
+    ],
   };
 
   const chatToggle = document.getElementById("chat-toggle");
@@ -322,28 +406,27 @@ const ChatQuiz = (() => {
 
   const handleOption = (choice) => {
     addUserMessage(choice);
-    const hasNextStep = stepIndex + 1 < chatFlow.length;
-    const avatarReaction = avatarMatchReplies[currentAvatar];
-    const shouldReact =
-      hasNextStep && avatarReaction && avatarReaction.option === choice;
+    const avatarReactions = avatarMatchReplies[currentAvatar] || [];
+    const reactionConfig = avatarReactions[stepIndex];
+    const shouldReact = reactionConfig && reactionConfig.option === choice;
 
     if (shouldReact) {
       schedule(() => {
-        addBotMessage(avatarReaction.reply);
+        addBotMessage(reactionConfig.reply);
       }, 280);
     }
 
+    const delayBeforeNext = shouldReact ? 1000 : 450;
     stepIndex += 1;
 
     if (stepIndex < chatFlow.length) {
-      const delayBeforeNext = shouldReact ? 1000 : 450;
       schedule(() => {
         askCurrentStep();
       }, delayBeforeNext);
     } else {
       schedule(() => {
         renderCompletion();
-      }, 380);
+      }, delayBeforeNext);
     }
   };
 

--- a/chat.js
+++ b/chat.js
@@ -33,6 +33,17 @@ const ChatQuiz = (() => {
         "Spa casero con mascarillas y velas",
       ],
     },
+    {
+      prompt: "¿Qué cosas no pueden faltar en tu mundo?",
+      options: [
+        "Los bolsos",
+        "Las cámaras desechables",
+        "Los vinilos",
+        "Los coleccionables kawaii",
+        "Los tenis",
+        "Los stickers",
+      ],
+    },
   ];
 
   const VISITOR_COOKIE = "stayc_chat_visitor";
@@ -49,6 +60,33 @@ const ChatQuiz = (() => {
     "assets/avatars/yoon.webp",
   ];
 
+  const avatarMatchReplies = {
+    "assets/avatars/isa.webp": {
+      option: "Los bolsos",
+      reply: "¡A mí también me gustan los bolsos!",
+    },
+    "assets/avatars/j.webp": {
+      option: "Las cámaras desechables",
+      reply: "Siempre llevo una cámara para capturar recuerdos.",
+    },
+    "assets/avatars/seeun.webp": {
+      option: "Los stickers",
+      reply: "Decoro todo con stickers, ¡son lo máximo!",
+    },
+    "assets/avatars/sumin.webp": {
+      option: "Los vinilos",
+      reply: "El sonido en vinilo tiene una vibra única, ¿cierto?",
+    },
+    "assets/avatars/sieun.webp": {
+      option: "Los tenis",
+      reply: "Unos buenos tenis te acompañan a todas partes.",
+    },
+    "assets/avatars/yoon.webp": {
+      option: "Los coleccionables kawaii",
+      reply: "Todo lo kawaii me hace feliz, ¡somos dos!",
+    },
+  };
+
   const chatToggle = document.getElementById("chat-toggle");
   const chatbox = document.getElementById("chatbox");
   const chatClose = document.getElementById("chat-close");
@@ -56,6 +94,7 @@ const ChatQuiz = (() => {
   const optionsContainer = document.getElementById("chat-options");
   const activeTimeouts = new Set();
   let shouldStartNewSession = true;
+  let currentAvatar = null;
 
   if (!chatToggle || !chatbox || !chatClose || !messages || !optionsContainer) {
     return {};
@@ -283,12 +322,24 @@ const ChatQuiz = (() => {
 
   const handleOption = (choice) => {
     addUserMessage(choice);
+    const hasNextStep = stepIndex + 1 < chatFlow.length;
+    const avatarReaction = avatarMatchReplies[currentAvatar];
+    const shouldReact =
+      hasNextStep && avatarReaction && avatarReaction.option === choice;
+
+    if (shouldReact) {
+      schedule(() => {
+        addBotMessage(avatarReaction.reply);
+      }, 280);
+    }
+
     stepIndex += 1;
 
     if (stepIndex < chatFlow.length) {
+      const delayBeforeNext = shouldReact ? 1000 : 450;
       schedule(() => {
         askCurrentStep();
-      }, 450);
+      }, delayBeforeNext);
     } else {
       schedule(() => {
         renderCompletion();
@@ -299,6 +350,7 @@ const ChatQuiz = (() => {
   const pickAvatar = () => {
     const randomIndex = Math.floor(Math.random() * avatarChoices.length);
     const chosenAvatar = avatarChoices[randomIndex];
+    currentAvatar = chosenAvatar;
     chatbox.style.setProperty("--chat-avatar-url", `url("${chosenAvatar}")`);
   };
 

--- a/chat.js
+++ b/chat.js
@@ -37,8 +37,8 @@ const ChatQuiz = (() => {
 
   const VISITOR_COOKIE = "stayc_chat_visitor";
   const COMPLETED_COOKIE = "stayc_chat_completed";
-  const FIRST_TIME_MESSAGE = "¡Bienvenida! Empecemos con tu vibra STAYC. 💖";
-  const RETURNING_MESSAGE = "¡Hola de nuevo! Ya hiciste el test, ¿quieres volver a hacerlo?";
+  const FIRST_TIME_MESSAGE = "¡Bienvenida! ¿Quieres empezar a jugar y descubrir tu vibra STAYC? 💖";
+  const RETURNING_MESSAGE = "¡Hola de nuevo! Ya hiciste el test, ¿quieres volver a jugar?";
   let stepIndex = 0;
   const avatarChoices = [
     "assets/avatars/isa.webp",
@@ -219,6 +219,57 @@ const ChatQuiz = (() => {
     optionsContainer.appendChild(close);
   };
 
+  const renderStartOptions = () => {
+    optionsContainer.innerHTML = "";
+
+    const yesOption = document.createElement("button");
+    yesOption.type = "button";
+    yesOption.className = "chat-option";
+    yesOption.textContent = "Sí";
+    yesOption.addEventListener("click", () => {
+      addUserMessage("Sí");
+      optionsContainer.innerHTML = "";
+      schedule(() => {
+        askCurrentStep();
+      }, 320);
+    });
+
+    const noOption = document.createElement("button");
+    noOption.type = "button";
+    noOption.className = "chat-option";
+    noOption.textContent = "No";
+    noOption.addEventListener("click", () => {
+      addUserMessage("No");
+      optionsContainer.innerHTML = "";
+      schedule(() => {
+        renderEarlyExit();
+      }, 280);
+    });
+
+    optionsContainer.appendChild(yesOption);
+    optionsContainer.appendChild(noOption);
+  };
+
+  const renderEarlyExit = () => {
+    addBotMessage("Entendido. Cuando quieras empezar a jugar, aquí estaré. ✨");
+    optionsContainer.innerHTML = "";
+
+    const restart = document.createElement("button");
+    restart.type = "button";
+    restart.className = "chat-option";
+    restart.textContent = "Empezar quiz";
+    restart.addEventListener("click", startConversation);
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "chat-option";
+    close.textContent = "Cerrar chat";
+    close.addEventListener("click", closeChat);
+
+    optionsContainer.appendChild(restart);
+    optionsContainer.appendChild(close);
+  };
+
   const askCurrentStep = () => {
     const step = chatFlow[stepIndex];
     if (!step) {
@@ -262,9 +313,7 @@ const ChatQuiz = (() => {
     const introMessage = hasCompletedQuiz() ? RETURNING_MESSAGE : FIRST_TIME_MESSAGE;
     ensureVisitorId();
     addBotMessage(introMessage);
-    schedule(() => {
-      askCurrentStep();
-    }, 400);
+    renderStartOptions();
   };
 
   const openChat = () => {


### PR DESCRIPTION
## Summary
- add visitor and completion cookies to the chat quiz to track finished sessions
- personalize the intro message for returning users who already completed the quiz
- ensure quiz completion preserves a visitor identifier for future visits

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ef01fc3c83238b3a85d9fbbd3011)