### PR TITLE
Delay chat options until after bot replies

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -281,8 +281,12 @@ const ChatQuiz = (() => {
     scrollToBottom();
   };
 
-  const renderOptions = (options) => {
+  const clearOptions = () => {
     optionsContainer.innerHTML = "";
+  };
+
+  const renderOptions = (options) => {
+    clearOptions();
 
     options.forEach((option) => {
       const button = document.createElement("button");
@@ -296,8 +300,9 @@ const ChatQuiz = (() => {
 
   const renderCompletion = () => {
     markQuizCompleted();
+    clearOptions();
     addBotMessage("¡Listo! Gracias por jugar. ¿Quieres reiniciar?", true, () => {
-      optionsContainer.innerHTML = "";
+      clearOptions();
 
       const restart = document.createElement("button");
       restart.type = "button";
@@ -319,7 +324,7 @@ const ChatQuiz = (() => {
   };
 
   const renderStartOptions = () => {
-    optionsContainer.innerHTML = "";
+    clearOptions();
 
     const yesOption = document.createElement("button");
     yesOption.type = "button";
@@ -350,8 +355,9 @@ const ChatQuiz = (() => {
   };
 
   const renderEarlyExit = () => {
+    clearOptions();
     addBotMessage("Entendido. Cuando quieras empezar a jugar, aquí estaré. ✨", true, () => {
-      optionsContainer.innerHTML = "";
+      clearOptions();
 
       const restart = document.createElement("button");
       restart.type = "button";
@@ -377,6 +383,7 @@ const ChatQuiz = (() => {
       return;
     }
 
+    clearOptions();
     addBotMessage(step.prompt, true, () => {
       renderOptions(step.options);
     });
@@ -384,6 +391,7 @@ const ChatQuiz = (() => {
 
   const handleOption = (choice) => {
     addUserMessage(choice);
+    clearOptions();
     const avatarReactions = avatarMatchReplies[currentAvatar] || {};
     const reactionReply = avatarReactions[choice];
 
@@ -431,7 +439,7 @@ const ChatQuiz = (() => {
     removeTypingIndicators();
     pickAvatar();
     messages.innerHTML = "";
-    optionsContainer.innerHTML = "";
+    clearOptions();
     stepIndex = 0;
     shouldStartNewSession = false;
     ensureVisitorId();
@@ -454,7 +462,7 @@ const ChatQuiz = (() => {
     chatbox.classList.remove("open");
     chatToggle.setAttribute("aria-expanded", "false");
     messages.innerHTML = "";
-    optionsContainer.innerHTML = "";
+    clearOptions();
     shouldStartNewSession = true;
   };
 

--- a/chat.js
+++ b/chat.js
@@ -208,9 +208,16 @@ const ChatQuiz = (() => {
     return wrapper;
   };
 
-  const addBotMessage = (text, withTyping = true) => {
+  const addBotMessage = (text, withTyping = true, onDisplayed) => {
+    const handleDisplayed = () => {
+      if (typeof onDisplayed === "function") {
+        onDisplayed();
+      }
+    };
+
     if (!withTyping) {
       addBotBubble(text);
+      handleDisplayed();
       return;
     }
 
@@ -218,6 +225,7 @@ const ChatQuiz = (() => {
     schedule(() => {
       indicator.remove();
       addBotBubble(text);
+      handleDisplayed();
     }, 650);
   };
 
@@ -249,25 +257,26 @@ const ChatQuiz = (() => {
 
   const renderCompletion = () => {
     markQuizCompleted();
-    addBotMessage("¡Listo! Gracias por jugar. ¿Quieres reiniciar?");
-    optionsContainer.innerHTML = "";
+    addBotMessage("¡Listo! Gracias por jugar. ¿Quieres reiniciar?", true, () => {
+      optionsContainer.innerHTML = "";
 
-    const restart = document.createElement("button");
-    restart.type = "button";
-    restart.className = "chat-option";
-    restart.textContent = "Volver a empezar";
-    restart.addEventListener("click", startConversation);
+      const restart = document.createElement("button");
+      restart.type = "button";
+      restart.className = "chat-option";
+      restart.textContent = "Volver a empezar";
+      restart.addEventListener("click", startConversation);
 
-    const close = document.createElement("button");
-    close.type = "button";
-    close.className = "chat-option";
-    close.textContent = "Cerrar chat";
-    close.addEventListener("click", () => {
-      closeChat();
+      const close = document.createElement("button");
+      close.type = "button";
+      close.className = "chat-option";
+      close.textContent = "Cerrar chat";
+      close.addEventListener("click", () => {
+        closeChat();
+      });
+
+      optionsContainer.appendChild(restart);
+      optionsContainer.appendChild(close);
     });
-
-    optionsContainer.appendChild(restart);
-    optionsContainer.appendChild(close);
   };
 
   const renderStartOptions = () => {
@@ -302,23 +311,24 @@ const ChatQuiz = (() => {
   };
 
   const renderEarlyExit = () => {
-    addBotMessage("Entendido. Cuando quieras empezar a jugar, aquí estaré. ✨");
-    optionsContainer.innerHTML = "";
+    addBotMessage("Entendido. Cuando quieras empezar a jugar, aquí estaré. ✨", true, () => {
+      optionsContainer.innerHTML = "";
 
-    const restart = document.createElement("button");
-    restart.type = "button";
-    restart.className = "chat-option";
-    restart.textContent = "Empezar quiz";
-    restart.addEventListener("click", startConversation);
+      const restart = document.createElement("button");
+      restart.type = "button";
+      restart.className = "chat-option";
+      restart.textContent = "Empezar quiz";
+      restart.addEventListener("click", startConversation);
 
-    const close = document.createElement("button");
-    close.type = "button";
-    close.className = "chat-option";
-    close.textContent = "Cerrar chat";
-    close.addEventListener("click", closeChat);
+      const close = document.createElement("button");
+      close.type = "button";
+      close.className = "chat-option";
+      close.textContent = "Cerrar chat";
+      close.addEventListener("click", closeChat);
 
-    optionsContainer.appendChild(restart);
-    optionsContainer.appendChild(close);
+      optionsContainer.appendChild(restart);
+      optionsContainer.appendChild(close);
+    });
   };
 
   const askCurrentStep = () => {
@@ -328,8 +338,9 @@ const ChatQuiz = (() => {
       return;
     }
 
-    addBotMessage(step.prompt);
-    renderOptions(step.options);
+    addBotMessage(step.prompt, true, () => {
+      renderOptions(step.options);
+    });
   };
 
   const handleOption = (choice) => {
@@ -374,8 +385,9 @@ const ChatQuiz = (() => {
     shouldStartNewSession = false;
     const introMessage = hasCompletedQuiz() ? RETURNING_MESSAGE : FIRST_TIME_MESSAGE;
     ensureVisitorId();
-    addBotMessage(introMessage);
-    renderStartOptions();
+    addBotMessage(introMessage, true, () => {
+      renderStartOptions();
+    });
   };
 
   const openChat = () => {

--- a/chat.js
+++ b/chat.js
@@ -83,7 +83,7 @@ const ChatQuiz = (() => {
         "My energy is calm but firm, like when I practice in silence and suddenly get serious without warning.": "Ah, so we're alike... that calm that seems soft but works hard inside, 맞지?",
         "In friendship I'm the one who takes care, makes bad jokes, remembers details... but also the one who trips first.": "That sounds just like me... taking care and joking while tripping a bit, I like your vibe.",
         "A perfect Sunday is good food, a nice drama, playing with keropi... and resting at home in pajamas.": "You like keropi? Me too! There's nothing I like more than keropi! Except SWITH, hehe.",
-        "In my world there's Girl's Generation music, delicious food, a little bit of adorable chaos...": "Ah, so our worlds are alike... that makes me feel closer to you, SWITH.",
+        "In my world there's Girl's Generation music, delicious food, a little bit of adorable chaos... and STAYC ♡": "Ah, so our worlds are alike... that makes me feel closer to you, SWITH.",
       },
       "assets/avatars/sieun.webp": {
         "Active; when I do something, I do it with all my energy.": "Ah ~ I think we'd understand each other very well... Although I'm actually quite calm and tranquil; I reflect on things a lot.",
@@ -181,7 +181,19 @@ const ChatQuiz = (() => {
   };
 
   const scrollToBottom = () => {
-    messages.scrollTop = messages.scrollHeight;
+    if (!messages) {
+      return;
+    }
+
+    const stick = () => {
+      messages.scrollTop = messages.scrollHeight;
+    };
+
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(stick);
+    } else {
+      stick();
+    }
   };
 
   const schedule = (fn, delay) => {
@@ -283,6 +295,8 @@ const ChatQuiz = (() => {
 
   const clearOptions = () => {
     optionsContainer.innerHTML = "";
+    optionsContainer.scrollTop = 0;
+    scrollToBottom();
   };
 
   const renderOptions = (options) => {
@@ -296,6 +310,8 @@ const ChatQuiz = (() => {
       button.addEventListener("click", () => handleOption(option));
       optionsContainer.appendChild(button);
     });
+
+    scrollToBottom();
   };
 
   const renderCompletion = () => {
@@ -320,6 +336,7 @@ const ChatQuiz = (() => {
 
       optionsContainer.appendChild(restart);
       optionsContainer.appendChild(close);
+      scrollToBottom();
     });
   };
 
@@ -332,7 +349,7 @@ const ChatQuiz = (() => {
     yesOption.textContent = "Sí";
     yesOption.addEventListener("click", () => {
       addUserMessage("Sí");
-      optionsContainer.innerHTML = "";
+      clearOptions();
       schedule(() => {
         askCurrentStep();
       }, 320);
@@ -344,7 +361,7 @@ const ChatQuiz = (() => {
     noOption.textContent = "No";
     noOption.addEventListener("click", () => {
       addUserMessage("No");
-      optionsContainer.innerHTML = "";
+      clearOptions();
       schedule(() => {
         renderEarlyExit();
       }, 280);
@@ -373,6 +390,7 @@ const ChatQuiz = (() => {
 
       optionsContainer.appendChild(restart);
       optionsContainer.appendChild(close);
+      scrollToBottom();
     });
   };
 

--- a/chat.js
+++ b/chat.js
@@ -99,6 +99,45 @@ const ChatQuiz = (() => {
       },
     };
 
+  const avatarIntroMessages = {
+    "assets/avatars/isa.webp": {
+      firstTime:
+        "¡Hola! Soy Isa. ¿Te animas a descubrir juntas qué vibra STAYC compartimos hoy? 💄",
+      returning:
+        "¡Holiii, volvió Isa! Ya hicimos el test antes, ¿lo repetimos para ver si cambió tu vibra?",
+    },
+    "assets/avatars/j.webp": {
+      firstTime:
+        "¡Hey, soy J! Tengo mil preguntas para ti, ¿empezamos el quiz y vemos si coincidimos en energía? ✨",
+      returning:
+        "¡Siii, regresaste! Soy J otra vez. Ya lo jugamos, pero podemos repetirlo y seguir riendo juntas.",
+    },
+    "assets/avatars/seeun.webp": {
+      firstTime:
+        "¡Hola, soy Seeun! Vamos a jugar con calma y descubrir tu vibra STAYC, ¿sí? 🦊",
+      returning:
+        "SWITH linda, soy Seeun de nuevo~ Si quieres podemos rehacer el test y charlar otro ratito.",
+    },
+    "assets/avatars/sumin.webp": {
+      firstTime:
+        "Soy Sumin. Preparé este juego para conocerte mejor, ¿lista para empezar ahora mismo? ☕",
+      returning:
+        "Hola otra vez, habla Sumin. Ya completamos el quiz, pero podemos intentarlo de nuevo si quieres ♡",
+    },
+    "assets/avatars/sieun.webp": {
+      firstTime:
+        "Sieun aquí. Me encantaría saber todo sobre tu vibra, ¿le damos al quiz? 🎤",
+      returning:
+        "¡Reunión de nuevo! Soy Sieun. Ya tienes resultados, pero podemos compararlos si repetimos el test.",
+    },
+    "assets/avatars/yoon.webp": {
+      firstTime:
+        "¡Hii, soy Yoon! Estoy lista para jugar y descubrir tu vibra STAYC, ¿vienes conmigo? 💛",
+      returning:
+        "¡Yoon está de vuelta! Si quieres seguimos jugando el quiz hasta que encontremos tu mood perfecto~",
+    },
+  };
+
   const chatToggle = document.getElementById("chat-toggle");
   const chatbox = document.getElementById("chatbox");
   const chatClose = document.getElementById("chat-close");
@@ -375,6 +414,18 @@ const ChatQuiz = (() => {
     chatbox.style.setProperty("--chat-avatar-url", `url("${chosenAvatar}")`);
   };
 
+  const getIntroMessage = () => {
+    const avatarIntro = avatarIntroMessages[currentAvatar];
+    const fallback = hasCompletedQuiz() ? RETURNING_MESSAGE : FIRST_TIME_MESSAGE;
+    if (!avatarIntro) {
+      return fallback;
+    }
+
+    return hasCompletedQuiz()
+      ? avatarIntro.returning || RETURNING_MESSAGE
+      : avatarIntro.firstTime || FIRST_TIME_MESSAGE;
+  };
+
   const startConversation = () => {
     clearScheduledResponses();
     removeTypingIndicators();
@@ -383,9 +434,8 @@ const ChatQuiz = (() => {
     optionsContainer.innerHTML = "";
     stepIndex = 0;
     shouldStartNewSession = false;
-    const introMessage = hasCompletedQuiz() ? RETURNING_MESSAGE : FIRST_TIME_MESSAGE;
     ensureVisitorId();
-    addBotMessage(introMessage, true, () => {
+    addBotMessage(getIntroMessage(), true, () => {
       renderStartOptions();
     });
   };

--- a/styles.css
+++ b/styles.css
@@ -812,6 +812,7 @@ footer a:hover {
   right: 24px;
   width: 360px;
   max-width: calc(100% - 32px);
+  max-height: min(620px, calc(100vh - 140px));
   background: #ffffff;
   border-radius: 16px;
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
@@ -834,6 +835,7 @@ footer a:hover {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  flex-shrink: 0;
 }
 
 .chatbox-title {
@@ -889,13 +891,16 @@ footer a:hover {
   display: flex;
   flex-direction: column;
   gap: 14px;
+  flex: 1;
+  overflow: hidden;
 }
 
 .chat-messages {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-height: 420px;
+  flex: 1;
+  min-height: 140px;
   overflow-y: auto;
   padding-right: 4px;
 }
@@ -955,6 +960,25 @@ footer a:hover {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.chat-options::-webkit-scrollbar,
+.chat-messages::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-options::-webkit-scrollbar-thumb,
+.chat-messages::-webkit-scrollbar-thumb {
+  background: rgba(15, 23, 42, 0.25);
+  border-radius: 999px;
+}
+
+.chat-options::-webkit-scrollbar-track,
+.chat-messages::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .chat-option {
@@ -1045,6 +1069,7 @@ footer a:hover {
     width: 330px;
     right: 16px;
     bottom: 96px;
+    max-height: calc(100vh - 120px);
   }
 
   .chatbox-body {
@@ -1150,6 +1175,7 @@ footer a:hover {
     right: 12px;
     bottom: 90px;
     border-radius: 14px;
+    max-height: calc(100vh - 110px);
   }
 
   .chat-toggle {


### PR DESCRIPTION
## Summary
- add a completion callback to the chat bot message helper so follow-up UI actions can wait until the typing indicator finishes
- delay all interactive option renders (start, quiz steps, completion, early exit) until after the bot finishes speaking for a smoother experience

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1f030aa083239a089359643266a5)