### PR TITLE
Add photocard quiz selection with album flow

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -846,6 +846,15 @@ const ChatQuiz = (() => {
     scrollToBottom();
   };
 
+  const autoDownloadImage = (dataUrl, filename = "stayc-photocard-ranking.png") => {
+    const link = document.createElement("a");
+    link.href = dataUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  };
+
   const renderCompletion = () => {
     markQuizCompleted();
     clearOptions();
@@ -853,7 +862,7 @@ const ChatQuiz = (() => {
     const share = document.createElement("button");
     share.type = "button";
     share.className = "chat-option";
-    share.textContent = "Compartir";
+    share.textContent = "Generar Imagen";
     share.addEventListener("click", async () => {
       share.disabled = true;
       const previousLabel = share.textContent;
@@ -862,13 +871,14 @@ const ChatQuiz = (() => {
       try {
         const imageUrl = await generatePhotocardShareImage();
         if (imageUrl) {
+          autoDownloadImage(imageUrl, "stayc-photocard-ranking.png");
           schedule(() => {
-            addBotMessage("¡Imagen lista para compartir! Descárgala y súbela a tus redes. 💖", true, () => {
+            addBotMessage("¡Imagen generada! Se descargó automáticamente, guárdala y compártela en tus redes. 💖", true, () => {
               addSharePreview(imageUrl);
             });
           }, 200);
         } else {
-          addBotMessage("Todavía no hay una photocard para compartir. Completa el quiz primero. ✨");
+          addBotMessage("Todavía no hay una photocard para generar. Completa el quiz primero. ✨");
         }
       } catch (error) {
         console.error("Error generating photocard share image", error);
@@ -913,7 +923,7 @@ const ChatQuiz = (() => {
       }
 
       schedule(() => {
-        addBotMessage("¿Quieres compartir tu photocard?", true, () => {
+        addBotMessage("¿Quieres generar la imagen de tu resultado?", true, () => {
           renderCompletion();
         });
       }, 900);
@@ -931,7 +941,7 @@ const ChatQuiz = (() => {
     bubble.className = "message-bubble share-preview";
 
     const content = document.createElement("p");
-    content.textContent = "Descarga y comparte tu photocard";
+    content.textContent = "Tu imagen de resultado está lista";
 
     const image = document.createElement("img");
     image.src = imageUrl;
@@ -940,7 +950,7 @@ const ChatQuiz = (() => {
 
     const download = document.createElement("a");
     download.href = imageUrl;
-    download.download = "stayc-photocard.png";
+    download.download = "stayc-photocard-ranking.png";
     download.className = "share-download";
     download.textContent = "Descargar imagen";
 
@@ -960,78 +970,155 @@ const ChatQuiz = (() => {
     }
 
     const { memberLabel, albumLabel, photocardUrl, variant } = lastPhotocardResult;
-
     const width = 1080;
     const height = 1920;
     shareCanvas.width = width;
     shareCanvas.height = height;
     const ctx = shareCanvas.getContext("2d");
 
-    const gradient = ctx.createLinearGradient(0, 0, 0, height);
-    gradient.addColorStop(0, "#ff7eb3");
-    gradient.addColorStop(1, "#6c63ff");
-    ctx.fillStyle = gradient;
+    const drawRoundedRect = (x, y, w, h, r) => {
+      ctx.beginPath();
+      ctx.moveTo(x + r, y);
+      ctx.lineTo(x + w - r, y);
+      ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+      ctx.lineTo(x + w, y + h - r);
+      ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+      ctx.lineTo(x + r, y + h);
+      ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+      ctx.lineTo(x, y + r);
+      ctx.quadraticCurveTo(x, y, x + r, y);
+      ctx.closePath();
+    };
+
+    ctx.fillStyle = "#f8fafc";
     ctx.fillRect(0, 0, width, height);
 
-    ctx.fillStyle = "rgba(255, 255, 255, 0.12)";
-    ctx.beginPath();
-    ctx.ellipse(width * 0.75, height * 0.08, 220, 120, 0, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.beginPath();
-    ctx.ellipse(width * 0.25, height * 0.85, 260, 140, 0, 0, Math.PI * 2);
+    const headerHeight = 320;
+    const headerGradient = ctx.createLinearGradient(0, 0, width, 0);
+    headerGradient.addColorStop(0, "#ff76b8");
+    headerGradient.addColorStop(1, "#ff9f7f");
+    ctx.fillStyle = headerGradient;
+    drawRoundedRect(60, 60, width - 120, headerHeight, 32);
     ctx.fill();
 
     ctx.fillStyle = "#ffffff";
-    ctx.font = "bold 42px Poppins, sans-serif";
     ctx.textAlign = "center";
-    ctx.fillText("STAYC Photocard Quiz", width / 2, 110);
-
+    ctx.font = "bold 54px Poppins, sans-serif";
+    ctx.fillText("Mi ranking STAYC", width / 2, 180);
     ctx.font = "28px Poppins, sans-serif";
-    ctx.fillText(`Tu vibra: ${memberLabel}`, width / 2, 170);
-    ctx.font = "24px Poppins, sans-serif";
-    ctx.fillText(albumLabel, width / 2, 215);
+    ctx.fillText("Resultado del Photocard Quiz", width / 2, 230);
 
-    const cardX = 160;
-    const cardY = 260;
-    const cardWidth = width - 320;
-    const cardHeight = 1200;
-    ctx.fillStyle = "#ffffff";
+    ctx.fillStyle = "rgba(255, 255, 255, 0.22)";
+    ctx.font = "20px Poppins, sans-serif";
+    ctx.fillText(`${memberLabel} · ${albumLabel}`, width / 2, 270);
+
+    const panelX = 70;
+    const panelY = headerHeight + 100;
+    const panelWidth = width - panelX * 2;
+    const panelHeight = 1180;
     ctx.shadowColor = "rgba(0, 0, 0, 0.18)";
-    ctx.shadowBlur = 28;
+    ctx.shadowBlur = 26;
     ctx.shadowOffsetY = 18;
-    ctx.fillRect(cardX, cardY, cardWidth, cardHeight);
+    ctx.fillStyle = "#ffffff";
+    drawRoundedRect(panelX, panelY, panelWidth, panelHeight, 28);
+    ctx.fill();
     ctx.shadowColor = "transparent";
 
-    const framePadding = 60;
-    const imageMaxWidth = cardWidth - framePadding * 2;
-    const imageMaxHeight = cardHeight - framePadding * 2 - 120;
-    const photo = await loadPhotocardImage(photocardUrl);
-    const ratio = Math.min(imageMaxWidth / photo.width, imageMaxHeight / photo.height);
-    const drawWidth = photo.width * ratio;
-    const drawHeight = photo.height * ratio;
-    const imageX = cardX + (cardWidth - drawWidth) / 2;
-    const imageY = cardY + 90;
-
-    ctx.drawImage(photo, imageX, imageY, drawWidth, drawHeight);
-
     ctx.fillStyle = "#0f172a";
-    ctx.font = "bold 30px Poppins, sans-serif";
     ctx.textAlign = "left";
-    ctx.fillText(memberLabel, cardX + framePadding, cardY + 58);
+    ctx.font = "bold 34px Poppins, sans-serif";
+    ctx.fillText("Tu ranking de vibra STAYC", panelX + 60, panelY + 70);
 
-    ctx.fillStyle = "#6c63ff";
-    ctx.font = "24px Poppins, sans-serif";
-    ctx.fillText(albumLabel, cardX + framePadding, cardY + 98);
+    ctx.fillStyle = "#6b7280";
+    ctx.font = "22px Poppins, sans-serif";
+    ctx.fillText("Incluye tu photocard y la era que te representa", panelX + 60, panelY + 110);
 
-    ctx.fillStyle = "#ff5fa2";
+    const rowBaseY = panelY + 170;
+    const rowHeight = 118;
+    const badgeColors = ["#ffd166", "#9cc0ff", "#b5e3d8"];
+    const rows = [
+      {
+        title: `${memberLabel} (${variant} ver.)`,
+        subtitle: "Tu photocard destacada",
+      },
+      {
+        title: albumLabel,
+        subtitle: "Era seleccionada por tu estilo",
+      },
+      {
+        title: "Mood SWITH: brillante & cool",
+        subtitle: "Generado con tus respuestas del quiz",
+      },
+    ];
+
+    rows.forEach((row, index) => {
+      const y = rowBaseY + index * (rowHeight + 16);
+      drawRoundedRect(panelX + 50, y, panelWidth * 0.5, rowHeight, 18);
+      ctx.fillStyle = "#f8fafc";
+      ctx.fill();
+
+      ctx.fillStyle = badgeColors[index % badgeColors.length];
+      drawRoundedRect(panelX + 62, y + 22, 48, 48, 12);
+      ctx.fill();
+
+      ctx.fillStyle = "#0f172a";
+      ctx.font = "bold 26px Poppins, sans-serif";
+      ctx.fillText(index + 1, panelX + 78, y + 55);
+
+      ctx.fillStyle = "#0f172a";
+      ctx.font = "bold 26px Poppins, sans-serif";
+      ctx.fillText(row.title, panelX + 126, y + 55);
+
+      ctx.fillStyle = "#6b7280";
+      ctx.font = "20px Poppins, sans-serif";
+      ctx.fillText(row.subtitle, panelX + 126, y + 88);
+    });
+
+    const photoAreaX = panelX + panelWidth * 0.55;
+    const photoAreaY = panelY + 150;
+    const photoAreaWidth = panelWidth * 0.35;
+    const photoAreaHeight = panelHeight - 280;
+
+    ctx.fillStyle = "#f8fafc";
+    drawRoundedRect(photoAreaX, photoAreaY, photoAreaWidth, photoAreaHeight, 24);
+    ctx.fill();
+
+    ctx.fillStyle = "#ff76b8";
     ctx.font = "bold 22px Poppins, sans-serif";
     ctx.textAlign = "center";
-    ctx.fillText(`Versión ${variant}`, width / 2, cardY + cardHeight - 30);
+    ctx.fillText("Photocard", photoAreaX + photoAreaWidth / 2, photoAreaY + 38);
 
-    ctx.fillStyle = "#ffffff";
+    ctx.fillStyle = "#0f172a";
+    ctx.font = "20px Poppins, sans-serif";
+    ctx.fillText(`${memberLabel} · ${albumLabel}`, photoAreaX + photoAreaWidth / 2, photoAreaY + 76);
+
+    const photo = await loadPhotocardImage(photocardUrl);
+    const availableWidth = photoAreaWidth - 70;
+    const availableHeight = photoAreaHeight - 140;
+    const ratio = Math.min(availableWidth / photo.width, availableHeight / photo.height);
+    const drawWidth = photo.width * ratio;
+    const drawHeight = photo.height * ratio;
+    const imageX = photoAreaX + (photoAreaWidth - drawWidth) / 2;
+    const imageY = photoAreaY + 110;
+
+    ctx.shadowColor = "rgba(0, 0, 0, 0.2)";
+    ctx.shadowBlur = 20;
+    ctx.shadowOffsetY = 14;
+    ctx.drawImage(photo, imageX, imageY, drawWidth, drawHeight);
+    ctx.shadowColor = "transparent";
+
+    ctx.fillStyle = "#ff9f7f";
+    ctx.font = "bold 20px Poppins, sans-serif";
+    ctx.fillText(`Versión ${variant}`, photoAreaX + photoAreaWidth / 2, imageY + drawHeight + 42);
+
+    ctx.fillStyle = "#6b7280";
+    ctx.font = "18px Poppins, sans-serif";
+    ctx.fillText("Generado con amor por STAYC & SWITH", photoAreaX + photoAreaWidth / 2, imageY + drawHeight + 78);
+
+    ctx.fillStyle = "#0f172a";
     ctx.font = "20px Poppins, sans-serif";
     ctx.textAlign = "center";
-    ctx.fillText("Comparte tu vibra STAYC ✨", width / 2, height - 80);
+    ctx.fillText("Comparte tu ranking en redes y etiquétanos ✨", width / 2, height - 80);
 
     return shareCanvas.toDataURL("image/png");
   };

--- a/chat.js
+++ b/chat.js
@@ -1,49 +1,67 @@
 const ChatQuiz = (() => {
   const chatFlow = [
-{
-  prompt: "What type of energy represents you best?",
-  options: [
-    "I might seem cold at first, but I'm actually very warm and I laugh a lot.",
-    "My energy is calm but firm, like when I practice in silence and suddenly get serious without warning.",
-    "Active; when I do something, I do it with all my energy.",
-    "Super energetic with my friends! And with a very powerful laugh. But I also have my calm moments.",
-    "Pure energy! I'm hyperactive, playful, and the life of the party.",
-    "I look calm, but when I'm comfortable I have a 4D personality and I'm very playful.",
-  ],
-},
-{
-  prompt: "How do you behave in a relationship or friendship?",
-  options: [
-    "I'm the one who listens, smiles with you, and gives you strength without you even realizing it.",
-    "I'm not a direct person, so I try to say things subtly to my friends... And I get a bit pouty sometimes~",
-    "I try to give encouragement and support to my friends, especially by making them laugh and saying nice things to them.",
-    "I'm like the mom of my friend group; I'm always looking out for their well-being.",
-    "Playful; I'm always hugging my friends or looking to play with them.",
-    "In friendship I'm the one who takes care, makes bad jokes, remembers details... but also the one who trips first.",
-  ],
-},
-{
-  prompt: "What plan makes you happy on a Sunday?",
-  options: [
-    "Going out to a café to talk with a friend for hours!",
-    "Planning my next trip to a majestic city like LA or similar.",
-    "A perfect Sunday is good food, a nice drama, playing with keropi... and resting at home in pajamas.",
-    "Video games, anime, consuming k-pop content.",
-    "Anything related to animals! They're adorable... Maybe going to a cat café?",
-    "Dramas, candy crush, sweet snacks...",
-  ],
-},
-{
-  prompt: "What things can't be missing from your world?",
-  options: [
-    "Music, a good coffee, shopping, friends... and STAYC ♡.",
-    "My favorite k-pop group, my video games, my favorite snacks, my friends, and STAYC ♡.",
-    "The important people in my life, animals, and STAYC ♡.",
-    "My headphones, organization, and STAYC's music ♡.",
-    "In my world there's Girl's Generation music, delicious food, a little bit of adorable chaos... and STAYC ♡",
-    "Fantasy! Series, books, movies... and STAYC ♡",
-  ],
-},
+    {
+      prompt: "What type of energy represents you best?",
+      options: [
+        "I might seem cold at first, but I'm actually very warm and I laugh a lot.",
+        "My energy is calm but firm, like when I practice in silence and suddenly get serious without warning.",
+        "Active; when I do something, I do it with all my energy.",
+        "Super energetic with my friends! And with a very powerful laugh. But I also have my calm moments.",
+        "Pure energy! I'm hyperactive, playful, and the life of the party.",
+        "I look calm, but when I'm comfortable I have a 4D personality and I'm very playful.",
+      ],
+    },
+    {
+      prompt: "How do you behave in a relationship or friendship?",
+      options: [
+        "I'm the one who listens, smiles with you, and gives you strength without you even realizing it.",
+        "I'm not a direct person, so I try to say things subtly to my friends... And I get a bit pouty sometimes~",
+        "I try to give encouragement and support to my friends, especially by making them laugh and saying nice things to them.",
+        "I'm like the mom of my friend group; I'm always looking out for their well-being.",
+        "Playful; I'm always hugging my friends or looking to play with them.",
+        "In friendship I'm the one who takes care, makes bad jokes, remembers details... but also the one who trips first.",
+      ],
+    },
+    {
+      prompt: "What plan makes you happy on a Sunday?",
+      options: [
+        "Going out to a café to talk with a friend for hours!",
+        "Planning my next trip to a majestic city like LA or similar.",
+        "A perfect Sunday is good food, a nice drama, playing with keropi... and resting at home in pajamas.",
+        "Video games, anime, consuming k-pop content.",
+        "Anything related to animals! They're adorable... Maybe going to a cat café?",
+        "Dramas, candy crush, sweet snacks...",
+      ],
+    },
+    {
+      prompt: "What things can't be missing from your world?",
+      options: [
+        "Music, a good coffee, shopping, friends... and STAYC ♡.",
+        "My favorite k-pop group, my video games, my favorite snacks, my friends, and STAYC ♡.",
+        "The important people in my life, animals, and STAYC ♡.",
+        "My headphones, organization, and STAYC's music ♡.",
+        "In my world there's Girl's Generation music, delicious food, a little bit of adorable chaos... and STAYC ♡",
+        "Fantasy! Series, books, movies... and STAYC ♡",
+      ],
+    },
+    {
+      prompt: "¿Qué estilo visual encaja mejor contigo?",
+      options: [
+        "Cute, colorido y con una vibra alegre",
+        "Elegante y minimalista, con detalles sofisticados",
+        "Oscuro/edgy, con un punto rebelde",
+        "Retro pop, con un toque nostálgico",
+      ],
+    },
+    {
+      prompt: "¿Qué tipo de música te imaginas para tu comeback ideal?",
+      options: [
+        "Un himno veraniego y refrescante",
+        "Un sonido powerful y girl crush",
+        "Algo juguetón y pegadizo para subir el ánimo",
+        "Una balada/medio tiempo emotiva",
+      ],
+    },
   ];
 
   const VISITOR_COOKIE = "stayc_chat_visitor";
@@ -51,6 +69,15 @@ const ChatQuiz = (() => {
   const FIRST_TIME_MESSAGE = "¡Bienvenida! ¿Quieres empezar a jugar y descubrir tu vibra STAYC? 💖";
   const RETURNING_MESSAGE = "¡Hola de nuevo! Ya hiciste el test, ¿quieres volver a jugar?";
   let stepIndex = 0;
+  const memberScores = {
+    isa: 0,
+    j: 0,
+    seeun: 0,
+    sumin: 0,
+    sieun: 0,
+    yoon: 0,
+  };
+  const preferredAlbums = new Set();
   const avatarChoices = [
     "assets/avatars/isa.webp",
     "assets/avatars/j.webp",
@@ -59,6 +86,329 @@ const ChatQuiz = (() => {
     "assets/avatars/sieun.webp",
     "assets/avatars/yoon.webp",
   ];
+
+  const albumLabels = {
+    sobad: "SO BAD era",
+    stereotype: "STEREOTYPE era",
+    asap: "ASAP era",
+    weneedlove: "WE NEED LOVE era",
+    teenfresh: "TEENFRESH era",
+    metamorphic: "METAMORPHIC era",
+  };
+
+  const memberLabels = {
+    isa: "Isa",
+    j: "J",
+    seeun: "Seeun",
+    sumin: "Sumin",
+    sieun: "Sieun",
+    yoon: "Yoon",
+  };
+
+  const optionMemberMap = {
+    "I might seem cold at first, but I'm actually very warm and I laugh a lot.": "isa",
+    "My energy is calm but firm, like when I practice in silence and suddenly get serious without warning.": "sumin",
+    "Active; when I do something, I do it with all my energy.": "sieun",
+    "Super energetic with my friends! And with a very powerful laugh. But I also have my calm moments.": "j",
+    "Pure energy! I'm hyperactive, playful, and the life of the party.": "yoon",
+    "I look calm, but when I'm comfortable I have a 4D personality and I'm very playful.": "seeun",
+    "I'm the one who listens, smiles with you, and gives you strength without you even realizing it.": "isa",
+    "I'm not a direct person, so I try to say things subtly to my friends... And I get a bit pouty sometimes~": "seeun",
+    "I try to give encouragement and support to my friends, especially by making them laugh and saying nice things to them.": "j",
+    "I'm like the mom of my friend group; I'm always looking out for their well-being.": "isa",
+    "Playful; I'm always hugging my friends or looking to play with them.": "yoon",
+    "In friendship I'm the one who takes care, makes bad jokes, remembers details... but also the one who trips first.": "sumin",
+    "Going out to a café to talk with a friend for hours!": "isa",
+    "Planning my next trip to a majestic city like LA or similar.": "sieun",
+    "A perfect Sunday is good food, a nice drama, playing with keropi... and resting at home in pajamas.": "sumin",
+    "Video games, anime, consuming k-pop content.": "yoon",
+    "Anything related to animals! They're adorable... Maybe going to a cat café?": "j",
+    "Dramas, candy crush, sweet snacks...": "seeun",
+    "Music, a good coffee, shopping, friends... and STAYC ♡.": "isa",
+    "My favorite k-pop group, my video games, my favorite snacks, my friends, and STAYC ♡.": "yoon",
+    "The important people in my life, animals, and STAYC ♡.": "j",
+    "My headphones, organization, and STAYC's music ♡.": "sieun",
+    "In my world there's Girl's Generation music, delicious food, a little bit of adorable chaos... and STAYC ♡": "sumin",
+    "Fantasy! Series, books, movies... and STAYC ♡": "seeun",
+  };
+
+  const optionAlbumMap = {
+    "Cute, colorido y con una vibra alegre": ["teenfresh", "asap"],
+    "Elegante y minimalista, con detalles sofisticados": ["stereotype", "weneedlove"],
+    "Oscuro/edgy, con un punto rebelde": ["metamorphic", "sobad"],
+    "Retro pop, con un toque nostálgico": ["sobad", "asap"],
+    "Un himno veraniego y refrescante": ["teenfresh", "weneedlove", "asap"],
+    "Un sonido powerful y girl crush": ["metamorphic", "stereotype"],
+    "Algo juguetón y pegadizo para subir el ánimo": ["sobad", "asap", "teenfresh"],
+    "Una balada/medio tiempo emotiva": ["weneedlove", "stereotype"],
+  };
+
+  const photocardPool = {
+    sobad: {
+      isa: {
+        base: [
+          "assets/photocards/sobad/isad.jpg",
+          "assets/photocards/sobad/isal.png",
+        ],
+        special: "assets/photocards/sobad/isas.png",
+      },
+      j: {
+        base: [
+          "assets/photocards/sobad/jd.jpg",
+          "assets/photocards/sobad/jl.jpg",
+        ],
+        special: "assets/photocards/sobad/js.png",
+      },
+      seeun: {
+        base: [
+          "assets/photocards/sobad/seeund.jpg",
+          "assets/photocards/sobad/seeunl.jpg",
+        ],
+        special: "assets/photocards/sobad/seeuns.png",
+      },
+      sieun: {
+        base: [
+          "assets/photocards/sobad/sieund.jpg",
+          "assets/photocards/sobad/sieunl.jpg",
+        ],
+        special: "assets/photocards/sobad/sieuns.png",
+      },
+      sumin: {
+        base: [
+          "assets/photocards/sobad/sumind.jpg",
+          "assets/photocards/sobad/suminl.jpg",
+        ],
+        special: "assets/photocards/sobad/sumins.png",
+      },
+      yoon: {
+        base: [
+          "assets/photocards/sobad/yoond.jpg",
+          "assets/photocards/sobad/yoonl.jpg",
+        ],
+        special: "assets/photocards/sobad/yoons.png",
+      },
+    },
+    stereotype: {
+      isa: {
+        base: [
+          "assets/photocards/stereotype/isaa.jpg",
+          "assets/photocards/stereotype/isab.jpg",
+        ],
+        special: "assets/photocards/stereotype/isas.png",
+      },
+      j: {
+        base: [
+          "assets/photocards/stereotype/ja.jpg",
+          "assets/photocards/stereotype/jb.jpg",
+        ],
+        special: "assets/photocards/stereotype/js.png",
+      },
+      seeun: {
+        base: [
+          "assets/photocards/stereotype/seeuna.jpg",
+          "assets/photocards/stereotype/seeunb.jpg",
+        ],
+        special: "assets/photocards/stereotype/seeuns.png",
+      },
+      sieun: {
+        base: [
+          "assets/photocards/stereotype/sieuna.jpg",
+          "assets/photocards/stereotype/sieunb.jpg",
+        ],
+        special: "assets/photocards/stereotype/sieuns.png",
+      },
+      sumin: {
+        base: [
+          "assets/photocards/stereotype/sumina.jpg",
+          "assets/photocards/stereotype/suminb.jpg",
+        ],
+        special: "assets/photocards/stereotype/sumins.png",
+      },
+      yoon: {
+        base: [
+          "assets/photocards/stereotype/yoona.jpg",
+          "assets/photocards/stereotype/yoonb.jpg",
+        ],
+        special: "assets/photocards/stereotype/yoons.png",
+      },
+    },
+    asap: {
+      isa: {
+        base: [
+          "assets/photocards/asap/isaa.jpg",
+          "assets/photocards/asap/isab.jpg",
+        ],
+        special: "assets/photocards/asap/isas.png",
+      },
+      j: {
+        base: [
+          "assets/photocards/asap/ja.jpg",
+          "assets/photocards/asap/jb.jpg",
+        ],
+        special: "assets/photocards/asap/js.png",
+      },
+      seeun: {
+        base: [
+          "assets/photocards/asap/seeuna.jpg",
+          "assets/photocards/asap/seeunb.jpg",
+        ],
+        special: "assets/photocards/asap/seeuns.png",
+      },
+      sieun: {
+        base: [
+          "assets/photocards/asap/sieuna.jpg",
+          "assets/photocards/asap/sieunb.jpg",
+        ],
+        special: "assets/photocards/asap/sieuns.png",
+      },
+      sumin: {
+        base: [
+          "assets/photocards/asap/sumina.png",
+          "assets/photocards/asap/suminb.jpg",
+        ],
+        special: "assets/photocards/asap/sumins.png",
+      },
+      yoon: {
+        base: [
+          "assets/photocards/asap/yoona.jpg",
+          "assets/photocards/asap/yoonb.jpg",
+        ],
+        special: "assets/photocards/asap/yoons.png",
+      },
+    },
+    weneedlove: {
+      isa: {
+        base: [
+          "assets/photocards/weneedlove/isaa.jpg",
+          "assets/photocards/weneedlove/isab.jpg",
+        ],
+        special: "assets/photocards/weneedlove/isas.png",
+      },
+      j: {
+        base: [
+          "assets/photocards/weneedlove/ja.jpg",
+          "assets/photocards/weneedlove/jb.jpg",
+        ],
+        special: "assets/photocards/weneedlove/js.png",
+      },
+      seeun: {
+        base: [
+          "assets/photocards/weneedlove/seeuna.jpg",
+          "assets/photocards/weneedlove/seeunb.jpg",
+        ],
+        special: "assets/photocards/weneedlove/seeuns.png",
+      },
+      sieun: {
+        base: [
+          "assets/photocards/weneedlove/sieuna.jpg",
+          "assets/photocards/weneedlove/sieunb.jpg",
+        ],
+        special: "assets/photocards/weneedlove/sieuns.png",
+      },
+      sumin: {
+        base: [
+          "assets/photocards/weneedlove/sumina.jpg",
+          "assets/photocards/weneedlove/suminb.jpg",
+        ],
+        special: "assets/photocards/weneedlove/sumins.png",
+      },
+      yoon: {
+        base: [
+          "assets/photocards/weneedlove/yoona.jpg",
+          "assets/photocards/weneedlove/yoonb.jpg",
+        ],
+        special: "assets/photocards/weneedlove/yoons.png",
+      },
+    },
+    teenfresh: {
+      isa: {
+        base: [
+          "assets/photocards/teenfresh/isaa.jpg",
+          "assets/photocards/teenfresh/isab.jpg",
+        ],
+        special: "assets/photocards/teenfresh/isas.png",
+      },
+      j: {
+        base: [
+          "assets/photocards/teenfresh/ja.jpg",
+          "assets/photocards/teenfresh/jb.jpg",
+        ],
+        special: "assets/photocards/teenfresh/js.png",
+      },
+      seeun: {
+        base: [
+          "assets/photocards/teenfresh/seeuna.jpg",
+          "assets/photocards/teenfresh/seeunb.jpg",
+        ],
+        special: "assets/photocards/teenfresh/seeuns.png",
+      },
+      sieun: {
+        base: [
+          "assets/photocards/teenfresh/sieuna.jpg",
+          "assets/photocards/teenfresh/sieunb.jpg",
+        ],
+        special: "assets/photocards/teenfresh/sieuns.png",
+      },
+      sumin: {
+        base: [
+          "assets/photocards/teenfresh/sumina.jpg",
+          "assets/photocards/teenfresh/suminb.jpg",
+        ],
+        special: "assets/photocards/teenfresh/sumins.png",
+      },
+      yoon: {
+        base: [
+          "assets/photocards/teenfresh/yoona.jpg",
+          "assets/photocards/teenfresh/yoonb.jpg",
+        ],
+        special: "assets/photocards/teenfresh/yoons.png",
+      },
+    },
+    metamorphic: {
+      isa: {
+        base: [
+          "assets/photocards/metamorphic/isaa.jpg",
+          "assets/photocards/metamorphic/isab.jpg",
+        ],
+        special: "assets/photocards/metamorphic/isas.png",
+      },
+      j: {
+        base: [
+          "assets/photocards/metamorphic/ja.jpg",
+          "assets/photocards/metamorphic/jb.jpg",
+        ],
+        special: "assets/photocards/metamorphic/js.png",
+      },
+      seeun: {
+        base: [
+          "assets/photocards/metamorphic/seeuna.jpg",
+          "assets/photocards/metamorphic/seeunb.jpg",
+        ],
+        special: "assets/photocards/metamorphic/seeuns.png",
+      },
+      sieun: {
+        base: [
+          "assets/photocards/metamorphic/sieuna.jpg",
+          "assets/photocards/metamorphic/sieunb.jpg",
+        ],
+        special: "assets/photocards/metamorphic/sieuns.png",
+      },
+      sumin: {
+        base: [
+          "assets/photocards/metamorphic/sumina.jpg",
+          "assets/photocards/metamorphic/suminb.jpg",
+        ],
+        special: "assets/photocards/metamorphic/sumins.png",
+      },
+      yoon: {
+        base: [
+          "assets/photocards/metamorphic/yoona.jpg",
+          "assets/photocards/metamorphic/yoonb.jpg",
+        ],
+        special: "assets/photocards/metamorphic/yoons.png",
+      },
+    },
+  };
 
   const avatarMatchReplies = {
       "assets/avatars/isa.webp": {
@@ -147,6 +497,20 @@ const ChatQuiz = (() => {
   let shouldStartNewSession = true;
   let currentAvatar = null;
 
+  const resetMemberScores = () => {
+    Object.keys(memberScores).forEach((key) => {
+      memberScores[key] = 0;
+    });
+  };
+
+  const addPreferredAlbums = (choice) => {
+    const albums = optionAlbumMap[choice];
+    if (!albums) {
+      return;
+    }
+    albums.forEach((album) => preferredAlbums.add(album));
+  };
+
   if (!chatToggle || !chatbox || !chatClose || !messages || !optionsContainer) {
     return {};
   }
@@ -231,6 +595,32 @@ const ChatQuiz = (() => {
     scrollToBottom();
   };
 
+  const addPhotocardBubble = (text, imageUrl) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "chat-message bot";
+
+    const avatar = document.createElement("div");
+    avatar.className = "chat-avatar-small";
+
+    const bubble = document.createElement("div");
+    bubble.className = "message-bubble photocard-bubble";
+
+    const content = document.createElement("p");
+    content.textContent = text;
+
+    const image = document.createElement("img");
+    image.src = imageUrl;
+    image.alt = text;
+    image.className = "photocard-preview";
+
+    bubble.appendChild(content);
+    bubble.appendChild(image);
+    wrapper.appendChild(avatar);
+    wrapper.appendChild(bubble);
+    messages.appendChild(wrapper);
+    scrollToBottom();
+  };
+
   const showTypingIndicator = () => {
     const wrapper = document.createElement("div");
     wrapper.className = "chat-message bot typing-indicator";
@@ -280,6 +670,55 @@ const ChatQuiz = (() => {
     }, 650);
   };
 
+  const addMemberScore = (choice) => {
+    const memberKey = optionMemberMap[choice];
+    if (memberKey && typeof memberScores[memberKey] === "number") {
+      memberScores[memberKey] += 1;
+    }
+  };
+
+  const chooseRandom = (list) => list[Math.floor(Math.random() * list.length)];
+
+  const getTopMember = () => {
+    const scores = Object.entries(memberScores);
+    const maxScore = Math.max(...scores.map(([, score]) => score));
+    const topMembers = scores
+      .filter(([, score]) => score === maxScore)
+      .map(([member]) => member);
+    return chooseRandom(topMembers);
+  };
+
+  const getAlbumChoice = () => {
+    if (preferredAlbums.size === 0) {
+      return chooseRandom(Object.keys(albumLabels));
+    }
+    const albumList = Array.from(preferredAlbums);
+    return chooseRandom(albumList);
+  };
+
+  const pickPhotocard = (member, album) => {
+    const albumPool = photocardPool[album];
+    if (!albumPool || !albumPool[member]) {
+      return null;
+    }
+
+    const { base = [], special } = albumPool[member];
+    const roll = Math.random();
+
+    if (special && roll <= 0.05) {
+      return { url: special, variant: "S" };
+    }
+
+    const baseOptions = base.length ? base : special ? [special] : [];
+    if (!baseOptions.length) {
+      return null;
+    }
+
+    const chosenBase = chooseRandom(baseOptions);
+    const variant = baseOptions.length > 1 && chosenBase === baseOptions[1] ? "B" : "A";
+    return { url: chosenBase, variant };
+  };
+
   const addUserMessage = (text) => {
     const wrapper = document.createElement("div");
     wrapper.className = "chat-message user";
@@ -317,26 +756,47 @@ const ChatQuiz = (() => {
   const renderCompletion = () => {
     markQuizCompleted();
     clearOptions();
-    addBotMessage("¡Listo! Gracias por jugar. ¿Quieres reiniciar?", true, () => {
-      clearOptions();
 
-      const restart = document.createElement("button");
-      restart.type = "button";
-      restart.className = "chat-option";
-      restart.textContent = "Volver a empezar";
-      restart.addEventListener("click", startConversation);
+    const restart = document.createElement("button");
+    restart.type = "button";
+    restart.className = "chat-option";
+    restart.textContent = "Volver a empezar";
+    restart.addEventListener("click", startConversation);
 
-      const close = document.createElement("button");
-      close.type = "button";
-      close.className = "chat-option";
-      close.textContent = "Cerrar chat";
-      close.addEventListener("click", () => {
-        closeChat();
-      });
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "chat-option";
+    close.textContent = "Cerrar chat";
+    close.addEventListener("click", () => {
+      closeChat();
+    });
 
-      optionsContainer.appendChild(restart);
-      optionsContainer.appendChild(close);
-      scrollToBottom();
+    optionsContainer.appendChild(restart);
+    optionsContainer.appendChild(close);
+    scrollToBottom();
+  };
+
+  const showPhotocardResult = () => {
+    const member = getTopMember();
+    const album = getAlbumChoice();
+    const memberLabel = memberLabels[member] || member;
+    const albumLabel = albumLabels[album] || album;
+    const photocard = pickPhotocard(member, album);
+
+    const introText = `¡Listo! Hoy tu vibra STAYC es ${memberLabel} en la era ${albumLabel}.`;
+
+    addBotMessage(introText, true, () => {
+      if (photocard) {
+        schedule(() => {
+          addPhotocardBubble(`Photocard ${memberLabel} (${photocard.variant} ver.)`, photocard.url);
+        }, 320);
+      }
+
+      schedule(() => {
+        addBotMessage("¿Quieres reiniciar?", true, () => {
+          renderCompletion();
+        });
+      }, 900);
     });
   };
 
@@ -397,7 +857,6 @@ const ChatQuiz = (() => {
   const askCurrentStep = () => {
     const step = chatFlow[stepIndex];
     if (!step) {
-      renderCompletion();
       return;
     }
 
@@ -412,6 +871,9 @@ const ChatQuiz = (() => {
     clearOptions();
     const avatarReactions = avatarMatchReplies[currentAvatar] || {};
     const reactionReply = avatarReactions[choice];
+
+    addMemberScore(choice);
+    addPreferredAlbums(choice);
 
     if (reactionReply) {
       schedule(() => {
@@ -428,7 +890,7 @@ const ChatQuiz = (() => {
       }, delayBeforeNext);
     } else {
       schedule(() => {
-        renderCompletion();
+        showPhotocardResult();
       }, delayBeforeNext);
     }
   };
@@ -455,6 +917,8 @@ const ChatQuiz = (() => {
   const startConversation = () => {
     clearScheduledResponses();
     removeTypingIndicators();
+    resetMemberScores();
+    preferredAlbums.clear();
     pickAvatar();
     messages.innerHTML = "";
     clearOptions();

--- a/styles.css
+++ b/styles.css
@@ -973,9 +973,10 @@ footer a:hover {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-height: 220px;
+  max-height: 340px;
   overflow-y: auto;
   padding-right: 4px;
+  flex-shrink: 0;
 }
 
 .chat-options::-webkit-scrollbar,

--- a/styles.css
+++ b/styles.css
@@ -972,7 +972,7 @@ footer a:hover {
 .chat-options {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   max-height: 220px;
   overflow-y: auto;
   padding-right: 4px;
@@ -999,9 +999,10 @@ footer a:hover {
   text-align: left;
   border: 1px solid #e5e7eb;
   background: #ffffff;
-  padding: 12px 14px;
+  padding: 14px 16px;
   border-radius: 12px;
   font-weight: 600;
+  font-size: 1rem;
   color: var(--text-dark);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;

--- a/styles.css
+++ b/styles.css
@@ -934,6 +934,19 @@ footer a:hover {
   line-height: 1.45;
 }
 
+.photocard-bubble {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.photocard-preview {
+  width: 180px;
+  border-radius: 14px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  border: 1px solid #e5e7eb;
+}
+
 .chat-message.bot .message-bubble {
   border-bottom-left-radius: 6px;
 }

--- a/styles.css
+++ b/styles.css
@@ -947,6 +947,38 @@ footer a:hover {
   border: 1px solid #e5e7eb;
 }
 
+.share-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.share-preview-image {
+  width: 220px;
+  border-radius: 14px;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.15);
+  border: 1px solid #e5e7eb;
+}
+
+.share-download {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  background: #0f172a;
+  color: #ffffff;
+  border-radius: 10px;
+  text-decoration: none;
+  font-weight: 600;
+  width: fit-content;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.share-download:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.2);
+}
+
 .chat-message.bot .message-bubble {
   border-bottom-left-radius: 6px;
 }


### PR DESCRIPTION
## Summary
- add two album/style questions to the chat quiz and track member scores per answer
- map quiz choices to album pools and pick a photocard for the winning member with weighted probabilities
- render the photocard preview inside the chat UI with refreshed styling and restart controls

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e36ef0ef483238dac9babfafc3cc8)