### PR TITLE
Add chat hint bubble for photocard quiz

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -259,6 +259,9 @@ const ChatQuiz = (() => {
   const chatClose = document.getElementById("chat-close");
   const messages = document.getElementById("chat-messages");
   const optionsContainer = document.getElementById("chat-options");
+  const chatHint = document.getElementById("chat-hint");
+  const chatHintClose = document.getElementById("chat-hint-close");
+  const CHAT_HINT_KEY = "staycChatHintDismissed";
   const activeTimeouts = new Set();
   let shouldStartNewSession = true;
   let currentAvatar = null;
@@ -309,6 +312,39 @@ const ChatQuiz = (() => {
   const clearScheduledResponses = () => {
     activeTimeouts.forEach((id) => clearTimeout(id));
     activeTimeouts.clear();
+  };
+
+  const hideChatHint = () => {
+    if (chatHint) {
+      chatHint.classList.remove("visible");
+    }
+  };
+
+  const dismissChatHint = () => {
+    hideChatHint();
+    try {
+      sessionStorage.setItem(CHAT_HINT_KEY, "true");
+    } catch (err) {
+      // Storage might be unavailable; ignore errors
+    }
+  };
+
+  const showChatHint = () => {
+    if (!chatHint) {
+      return;
+    }
+
+    try {
+      if (sessionStorage.getItem(CHAT_HINT_KEY) === "true") {
+        return;
+      }
+    } catch (err) {
+      // Continue without storage gating if unavailable
+    }
+
+    requestAnimationFrame(() => {
+      chatHint.classList.add("visible");
+    });
   };
 
   const removeTypingIndicators = () => {
@@ -929,6 +965,7 @@ const ChatQuiz = (() => {
   const openChat = () => {
     chatbox.classList.add("open");
     chatToggle.setAttribute("aria-expanded", "true");
+    dismissChatHint();
     if (shouldStartNewSession) {
       startConversation();
     }
@@ -953,6 +990,12 @@ const ChatQuiz = (() => {
   });
 
   chatClose.addEventListener("click", closeChat);
+
+  if (chatHintClose) {
+    chatHintClose.addEventListener("click", dismissChatHint);
+  }
+
+  showChatHint();
 
   return {
     open: openChat,

--- a/index.html
+++ b/index.html
@@ -288,6 +288,11 @@
           </footer>
         </div>
 
+        <div id="chat-hint" class="chat-hint" role="status" aria-live="polite">
+          <span>Guess your STAYC photocard here!</span>
+          <button id="chat-hint-close" class="chat-hint-close" aria-label="Dismiss chat hint">×</button>
+        </div>
+
         <button id="chat-toggle" class="chat-toggle" aria-label="Abrir chat interactivo" aria-expanded="false">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>

--- a/styles.css
+++ b/styles.css
@@ -800,6 +800,66 @@ footer a:hover {
   z-index: 1500;
 }
 
+.chat-hint {
+  position: fixed;
+  right: 24px;
+  bottom: 110px;
+  max-width: 260px;
+  background: #0f172a;
+  color: #ffffff;
+  padding: 14px 16px;
+  border-radius: 14px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  opacity: 0;
+  transform: translateY(6px);
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 1600;
+}
+
+.chat-hint::after {
+  content: "";
+  position: absolute;
+  right: 42px;
+  bottom: -10px;
+  border-width: 10px 10px 0 10px;
+  border-style: solid;
+  border-color: #0f172a transparent transparent transparent;
+}
+
+.chat-hint span {
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.chat-hint.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.chat-hint-close {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #ffffff;
+  border-radius: 8px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.chat-hint-close:hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: scale(1.03);
+}
+
 .chat-toggle:hover {
   transform: translateY(-2px);
   box-shadow: 0 16px 36px rgba(0, 0, 0, 0.3);
@@ -1119,6 +1179,11 @@ footer a:hover {
     max-height: calc(100vh - 120px);
   }
 
+  .chat-hint {
+    right: 16px;
+    bottom: 150px;
+  }
+
   .chatbox-body {
     padding: 14px;
   }
@@ -1223,6 +1288,12 @@ footer a:hover {
     bottom: 90px;
     border-radius: 14px;
     max-height: calc(100vh - 110px);
+  }
+
+  .chat-hint {
+    right: 12px;
+    bottom: 140px;
+    max-width: calc(100% - 32px);
   }
 
   .chat-toggle {


### PR DESCRIPTION
## Summary
- add a homepage hint bubble that highlights the photocard quiz chat entry point
- style the hint for desktop and mobile layouts with accessible dismissal controls
- wire chat logic to show the hint on first load and dismiss it when opened or closed

## Testing
- python -m http.server 8000


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee131333c8323802f8fadf5e83e09)