### PR TITLE
Remove sample S preview and fix special variant flag

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -529,7 +529,7 @@ const ChatQuiz = (() => {
 
     // 5% de probabilidad especial
     if (roll <= 0.05) {
-      return { url: special, variant: "S" };
+      return { url: special, variant: "s" };
     }
 
     // Selección normal


### PR DESCRIPTION
## Summary
- revert the sample S-version preview flow, returning to the original quiz completion share step
- correct the special photocard variant flag to use lowercase so the rare template styling renders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee5b85fc083239543cd657aacadf2)