### PR TITLE
Add Ko-fi support widget to main and results views

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,25 +266,6 @@
             </div>
           </main>
 
-          <section id="support-section" aria-label="Support the creator">
-            <div class="support-card">
-              <div class="support-text">
-                <h3>Enjoying the ranker?</h3>
-                <p>Support the project with a coffee on Ko-fi.</p>
-              </div>
-              <div class="support-widget">
-                <iframe
-                  id="kofiframe"
-                  class="kofi-iframe"
-                  src="https://ko-fi.com/satinfive/?hidefeed=true&widget=true&embed=true&preview=true"
-                  style="border:none;width:100%;padding:4px;background:#f9f9f9;"
-                  height="712"
-                  title="satinfive"
-                ></iframe>
-              </div>
-            </div>
-          </section>
-
           <footer>
             <p>Created with 🧡 for STAYC and SWITH</p>
             <div class="footer-links">
@@ -305,6 +286,25 @@
 </a>
             </div>
           </footer>
+
+          <section id="support-section" aria-label="Support the creator">
+            <div class="support-card">
+              <div class="support-text">
+                <h3>Enjoying the ranker?</h3>
+                <p>Support the project with a coffee on Ko-fi.</p>
+              </div>
+              <div class="support-widget">
+                <iframe
+                  id="kofiframe"
+                  class="kofi-iframe"
+                  src="https://ko-fi.com/satinfive/?hidefeed=true&widget=true&embed=true&preview=true"
+                  style="border:none;width:100%;padding:4px;background:#f9f9f9;"
+                  height="712"
+                  title="satinfive"
+                ></iframe>
+              </div>
+            </div>
+          </section>
         </div>
 
         <button id="chat-toggle" class="chat-toggle" aria-label="Abrir chat interactivo" aria-expanded="false">

--- a/index.html
+++ b/index.html
@@ -266,6 +266,25 @@
             </div>
           </main>
 
+          <section id="support-section" aria-label="Support the creator">
+            <div class="support-card">
+              <div class="support-text">
+                <h3>Enjoying the ranker?</h3>
+                <p>Support the project with a coffee on Ko-fi.</p>
+              </div>
+              <div class="support-widget">
+                <iframe
+                  id="kofiframe"
+                  class="kofi-iframe"
+                  src="https://ko-fi.com/satinfive/?hidefeed=true&widget=true&embed=true&preview=true"
+                  style="border:none;width:100%;padding:4px;background:#f9f9f9;"
+                  height="712"
+                  title="satinfive"
+                ></iframe>
+              </div>
+            </div>
+          </section>
+
           <footer>
             <p>Created with 🧡 for STAYC and SWITH</p>
             <div class="footer-links">

--- a/ranker.js
+++ b/ranker.js
@@ -9,6 +9,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const songSelectionContainer = document.getElementById("song-selection-container")
   const matchContainer = document.getElementById("match-container")
   const resultsContainer = document.getElementById("results-container")
+  const supportSection = document.getElementById("support-section")
   const progressBar = document.getElementById("progress-bar")
   const progressText = document.getElementById("progress-text")
   const currentRound = document.getElementById("current-round")
@@ -186,6 +187,11 @@ document.addEventListener("DOMContentLoaded", () => {
     TEENFRESH: "#ffde59",
   }
 
+  function toggleSupportSection(isVisible) {
+    if (!supportSection) return
+    supportSection.style.display = isVisible ? "block" : "none"
+  }
+
   // Initialize the app
   function init() {
     // Set up event listeners
@@ -210,6 +216,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Initialize song grid
     initializeSongGrid()
+
+    toggleSupportSection(true)
   }
 
   // Handle start button click
@@ -226,12 +234,14 @@ document.addEventListener("DOMContentLoaded", () => {
     settingsContainer.style.display = "none"
     songSelectionContainer.style.display = "block"
     updateSelectedCount()
+    toggleSupportSection(false)
   }
 
   // Back to settings from song selection
   function backToSettings() {
     songSelectionContainer.style.display = "none"
     settingsContainer.style.display = "block"
+    toggleSupportSection(true)
   }
 
   // Initialize song grid
@@ -387,6 +397,7 @@ document.addEventListener("DOMContentLoaded", () => {
     matchContainer.style.display = "flex"
     startButton.style.display = "none"
     restartButton.style.display = "inline-flex"
+    toggleSupportSection(false)
 
     // Show first match
     showMatch(0)
@@ -458,6 +469,7 @@ document.addEventListener("DOMContentLoaded", () => {
     matchContainer.style.display = "flex"
     startButton.style.display = "none"
     restartButton.style.display = "inline-flex"
+    toggleSupportSection(false)
 
     // Show first match
     showMatch(0)
@@ -591,6 +603,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // Update UI
     matchContainer.style.display = "none"
     resultsContainer.style.display = "block"
+    toggleSupportSection(true)
 
     // Generate share URL
     generateShareUrl(currentRankings)
@@ -948,6 +961,7 @@ document.addEventListener("DOMContentLoaded", () => {
     songSelectionContainer.style.display = "none"
     matchContainer.style.display = "none"
     resultsContainer.style.display = "none"
+    toggleSupportSection(true)
   }
 
   // Go back to the main menu
@@ -959,6 +973,7 @@ document.addEventListener("DOMContentLoaded", () => {
     resultsContainer.style.display = "none"
     startButton.style.display = "inline-flex"
     restartButton.style.display = "none"
+    toggleSupportSection(true)
 
     // Reset state
     currentMatchIndex = 0
@@ -995,6 +1010,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         settingsContainer.style.display = "none"
         resultsContainer.style.display = "block"
+        toggleSupportSection(true)
         return true
       }
     }

--- a/styles.css
+++ b/styles.css
@@ -762,6 +762,49 @@ progress::-moz-progress-bar {
   padding: 12px 25px;
 }
 
+/* Support Section */
+#support-section {
+  margin: 40px auto 0;
+  max-width: 520px;
+}
+
+.support-card {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 10px 30px var(--shadow);
+  padding: 18px;
+}
+
+.support-text {
+  text-align: center;
+  margin-bottom: 12px;
+}
+
+.support-text h3 {
+  margin-bottom: 6px;
+  font-size: 1.2rem;
+}
+
+.support-text p {
+  color: var(--text-muted);
+}
+
+.support-widget {
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f9f9f9;
+  border: 1px solid var(--border);
+}
+
+.kofi-iframe {
+  width: 100%;
+  height: 712px;
+  border: none;
+  display: block;
+  background: #f9f9f9;
+}
+
 /* Footer Styles */
 footer {
   margin-top: 50px;


### PR DESCRIPTION
## Summary
- add a Ko-fi support section near the bottom of the main page
- style the widget container so the embed stays centered and unobtrusive
- toggle the widget visibility so it shows on the menu and after results but stays hidden during ranking

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed33252808323801141d02fe740e6)